### PR TITLE
Add Handle + Datasource support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,18 @@ When adding this field to a section, the following options are available to you:
 * **Open links in a new window** enforces the hyperlink to spawn a new tab/window
 * **Hide this field on publish page** hides the hyperlink in the entry edit form
 
+## XSLT & Datasources
+
+Version 2.0 allows the use of XSLT templates to generate urls. Xpath statements can only be so complicated, the ability to use an XSLT template simplifies the use and generation of URLs especially when using other datasources to generate parts of the url. Such as a user friendly url containing the category, subcategory and article handles.
+
+Datasources are selected within the Field Settings panel when adding/editing the field details. They are accessible via XPath and XSLT in the same way they are available in the front-end. Keep in mind the more you add the longer it might take to generate the urls. Note that if you change a value used to generate the urls, these will not automatically update, you will need to re-save the entries.
+
+## Handle Field
+
+As a bonus addition with version 2.0 there's also a custom handle field baked in to the Entry URL. Before when one wanted to customize the link handle, say taken from an Article Title, you would have to create a separate field, for the handle, and explain to the customer that that they have to write the link field there. The new update simplifies this process.
+
+By Selecting a `handle_source` the javascript automatically ties itself to the original source field. When creating the entry, this will auto-generate a handle as the user fills in the orignal field. If they want to override the handle value, they can do so by clicking on the handle text. Once touched the handle will only sync when clicking on the refresh icon, same thing when opening an article which has been saved. Also once saved, the entry handle will appear as part of the full entry url, making it simpler for the person editing the entry to see the url with which the entry is accessible.
+
 ## Credits
 
 Big thanks to Rowan Lewis' Reflection Field, which comprises about 90% of this code! Thx.

--- a/assets/js/publish.js
+++ b/assets/js/publish.js
@@ -1,0 +1,112 @@
+(function($){
+
+	function string_to_slug(str) {
+		str = str.replace(/^\s+|\s+$/g, ''); // trim
+		str = str.toLowerCase();
+
+		// remove accents, swap ñ for n, etc
+		var from = "àáäâèéëêìíïîòóöôùúüûñç·/_,:;";
+		var to   = "aaaaeeeeiiiioooouuuunc------";
+		for (var i=0, l=from.length ; i<l ; i++) {
+			str = str.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
+		}
+
+		str = str.replace(/[^a-z0-9 -]/g, '') // remove invalid chars
+			.replace(/\s+/g, '-') // collapse whitespace and replace by -
+			.replace(/-+/g, '-'); // collapse dashes
+
+		if (str.indexOf('-', str.length - 1) !== -1){
+		str =str.slice(0,-1);
+		}
+
+		return str;
+	}
+
+	jQuery(document).ready(function () {
+
+		var $handleContainer = $('.url-entry-handle');
+		var source = $('*[name="fields[' + $handleContainer.data('source') + ']"]');
+
+		function updateHandle(){
+			var handle = string_to_slug(source.val()).substring(0,$handleContainer.data('length'));
+			$handleContainer.text(handle);
+
+			$handleContainer.closest('label').find('input').val(handle);
+		}
+
+		function setPrefix(){
+			var link = $handleContainer.closest('.frame').find('a').attr('href');
+			if (!link) {
+
+				var text = $handleContainer.closest('.frame').text().trim();
+
+				$handleContainer.closest('.frame').contents().filter(function(){
+					return this.nodeType === 3;
+				}).remove();
+
+				$handleContainer.before( "The handle will appear here: ");
+
+				$handleContainer.closest('.frame').append("<span style='float:right'>"+text+"</span>");
+				return;
+			}
+			var prefix = link.substr(0, link.indexOf($handleContainer.text()));
+			$handleContainer.before(prefix);
+		}
+
+		function setPostfix(){
+			var link = $handleContainer.closest('.frame').find('a').attr('href');
+			if (!link) return;
+			var postfix = link.substr(link.indexOf($handleContainer.text()) + $handleContainer.text().length );
+			$handleContainer.after(postfix);
+		}
+
+		function syncHandle(){			
+			updateHandle();
+			
+			$(document).on('change keyup','*[name="fields[' + $handleContainer.data('source') + ']"]',updateHandle);
+
+			$(document).on('blur keyup','.url-entry-handle',function(){
+				$(document).off('change keyup','*[name="fields[' + $handleContainer.data('source') + ']"]',updateHandle);
+				if ($handleContainer.parent().find('.fa-refresh').length == 0)
+					$handleContainer.parent().append('<i class="fa fa-refresh" style="color:#111;margin-left:5px;cursor:pointer;"></i>');
+			})
+		}
+
+		//convert inserted text to handle
+		$(document).on('blur','.url-entry-handle',function(){
+			var handle = string_to_slug($handleContainer.text()).substring(0,$handleContainer.data('length'));
+			$handleContainer.text(handle);
+
+			$handleContainer.closest('label').find('input').val(handle);
+		})
+
+		//convert inserted text to handle
+		$(document).on('click','.field-entry_url i.fa-refresh',function(){
+			syncHandle();
+			$(this).remove();
+		})
+
+		if ($handleContainer.hasClass('empty')){
+			syncHandle();
+			setPrefix();
+			setPostfix();
+		} else {
+			$handleContainer.parent().append('<i class="fa fa-refresh" style="color:#111;margin-left:5px;cursor:pointer;"></i>');
+		}
+
+		if ($handleContainer.length > 0){
+			//temporary css
+			$handleContainer.closest('label').contents().filter(function(){
+			    return this.nodeType === 3;
+			}).remove();
+			$handleContainer.closest('label').css('margin-top','-1.5rem');
+
+			$handleContainer.css('cursor','pointer');
+			$handleContainer.css('color','#000');
+			$handleContainer.parent().css('color','#888');
+			$handleContainer.closest('.frame').find('a').css('float','right');
+		}
+
+	});
+
+})(jQuery);

--- a/assets/js/publish.js
+++ b/assets/js/publish.js
@@ -22,7 +22,7 @@
 		return str;
 	}
 
-	jQuery(document).ready(function () {
+	$(document).ready(function () {
 
 		var $handleContainer = $('.url-entry-handle');
 		var source = $('*[name="fields[' + $handleContainer.data('source') + ']"]');
@@ -90,6 +90,9 @@
 			syncHandle();
 			setPrefix();
 			setPostfix();
+		} else if ($handleContainer.data('sync') && $handleContainer.text() == string_to_slug(source.val()).substring(0,$handleContainer.data('length'))){
+			//if has sync enabled and the text matches the source field
+			syncHandle();
 		} else {
 			$handleContainer.parent().append('<i class="fa fa-refresh" style="color:#111;margin-left:5px;cursor:pointer;"></i>');
 		}

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -75,6 +75,11 @@
 				),
 				array(
 					'page' => '/xmlimporter/importers/run/',
+					'delegate' => 'XMLImporterEntryPostCreate',
+					'callback' => 'compileImportFields',
+				),
+				array(
+					'page' => '/xmlimporter/importers/run/',
 					'delegate' => 'XMLImporterEntryPostEdit',
 					'callback' => 'compileImportFields',
 				),

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -203,7 +203,7 @@
 			// Only load on /publish/.../new/ OR /publish/.../edit/
 			if (in_array($page->_context['page'], array('new', 'edit'))) {
 				$page->addScriptToHead($assets_path . '/js/publish.js', $LOAD_NUMBER++);
-				$page->addStylesheetToHead('http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css');
+				$page->addStylesheetToHead('https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css');
 			}
 			
 		}

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -32,6 +32,9 @@
 					Symphony::Database()->query("ALTER TABLE `{$entries_table}` ADD COLUMN `handle` VARCHAR(255) DEFAULT NULL");
 				}
 			}
+			if( version_compare($prev_version, '2.2.0', '<') ){
+				Symphony::Database()->query("ALTER TABLE `tbl_fields_entry_url` ADD COLUMN `sync` ENUM('yes', 'no') DEFAULT 'no'");
+			}
 
 			return true;
 		}
@@ -48,6 +51,7 @@
 					`handle_source` VARCHAR(255) DEFAULT NULL,
 					`handle_length` TINYINT(3) UNSIGNED DEFAULT 255,
 					`hide` ENUM('yes', 'no') DEFAULT 'no',
+  					`sync` ENUM('yes', 'no') DEFAULT 'no',
 					PRIMARY KEY (`id`),
 					KEY `field_id` (`field_id`)
 				)

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -74,6 +74,11 @@
 					'callback'	=> 'compileFrontendFields'
 				),
 				array(
+					'page' => '/xmlimporter/importers/run/',
+					'delegate' => 'XMLImporterEntryPostEdit',
+					'callback' => 'compileImportFields',
+				),
+				array(
 					'page' => '/backend/',
 					'delegate' => 'InitialiseAdminPageHead',
 					'callback' => 'initializeAdmin',
@@ -161,6 +166,12 @@
 		}
 		
 		public function compileFrontendFields($context) {
+			foreach (self::$fields as $field) {
+				$field->compile($context['entry']);
+			}
+		}
+		
+		public function compileImportFields($context) {
 			foreach (self::$fields as $field) {
 				$field->compile($context['entry']);
 			}

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -142,11 +142,13 @@
 	            'http-host' => HTTP_HOST
 	        );
 
-			foreach ($datasources as $dsName) {
-				$ds = DatasourceManager::create($dsName, $params);
-				$arr = array();
-				$dsXml = $ds->execute($arr); 
-				$xml->appendChild($dsXml);
+			if ($datasources){
+				foreach ($datasources as $dsName) {
+					$ds = DatasourceManager::create($dsName, $params);
+					$arr = array();
+					$dsXml = $ds->execute($arr); 
+					$xml->appendChild($dsXml);
+				}
 			}
 
 			//in case there are url params they will also be added in the xml

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -95,7 +95,7 @@
 		Utilities:
 	-------------------------------------------------------------------------*/
 		
-		public function getDom($entry,$datasources = array()) {
+		public function getDom($entry,$datasources = array(),$entry_url_field_id) {
 			$entry_xml = new XMLElement('entry');
 			$data = $entry->getData();
 			
@@ -117,6 +117,8 @@
 				$field = FieldManager::fetch($field_id);
 				$field->appendFormattedElement($entry_xml, $values, false);
 			}
+
+			FieldManager::fetch($entry_url_field_id)->setReady(true);
 			
 			$xml = new XMLElement('data');
 			$xml->appendChild($entry_xml);

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -41,7 +41,6 @@
 			* Updated compatibility with 2.x.x
 		]]>
 		</release>
-		</release>
 		<release version="1.3.0" date="2012-06-21" min="2.3.x"><![CDATA[
 			* Added personalized labels supporting xPath at entry level instead of field level.
 		]]>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -29,6 +29,7 @@
 		<release version="2.0" date="2018-06-01" min="2.5.x"><![CDATA[
 			* Added support for Datasources and XSLT to generate urls
 			* Added support for handle overrides
+			* Added support for xml importer
 		]]>
 		<release version="1.3.2" date="2018-01-05" min="2.3.x" max="2.x.x"><![CDATA[
 			* Compatibility with PHP 7

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -26,6 +26,10 @@
 		<item type="image" url="http://symphonyextensions.com/nickdunn/entry_url_field/media/entry_url_field.png">Entry URL Field: Add a hyperlink in the backend to view an entry URL in the frontend</item>
 	</media>
 	<releases>
+		<release version="2.0" date="2018-06-01" min="2.5.x"><![CDATA[
+			* Added support for Datasources and XSLT to generate urls
+			* Added support for handle overrides
+		]]>
 		<release version="1.3.2" date="2018-01-05" min="2.3.x" max="2.x.x"><![CDATA[
 			* Compatibility with PHP 7
 		]]>
@@ -33,6 +37,7 @@
 		<release version="1.3.1" date="2016-03-06" min="2.3.x" max="2.x.x"><![CDATA[
 			* Updated compatibility with 2.x.x
 		]]>
+		</release>
 		</release>
 		<release version="1.3.0" date="2012-06-21" min="2.3.x"><![CDATA[
 			* Added personalized labels supporting xPath at entry level instead of field level.

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -30,8 +30,9 @@
 			* Added support for Datasources and XSLT to generate urls
 			* Added support for handle overrides
 			* Add delegate for XML Importer Post Create
-			* Added support for xml importer
+			* Added support for handle sync after initial save - only triggers if the generated handle matches the saved one.
 		]]>
+		</release>
 		<release version="1.3.2" date="2018-01-05" min="2.3.x" max="2.x.x"><![CDATA[
 			* Compatibility with PHP 7
 		]]>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -25,8 +25,12 @@
 		<item type="image" url="http://symphonyextensions.com/nickdunn/entry_url_field/media/entry_url_field.png">Entry URL Field: Add a hyperlink in the backend to view an entry URL in the frontend</item>
 	</media>
 	<releases>
+		<release version="2.2.0" date="2015-12-15" min="2.5.x"><![CDATA[
+			* Added support for handle sync after initial save - only triggers if the generated handle matches the saved one.
+		]]>
+		</release>
 		<release version="2.1.1" date="2015-04-01" min="2.5.x"><![CDATA[
-			* Add delegate for XML Importer Post Create
+			* Added delegate for XML Importer Post Create
 		]]>
 		</release>
 		<release version="2.1" date="2015-03-18" min="2.5.x"><![CDATA[

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -25,6 +25,11 @@
 		<item type="image" url="http://symphonyextensions.com/nickdunn/entry_url_field/media/entry_url_field.png">Entry URL Field: Add a hyperlink in the backend to view an entry URL in the frontend</item>
 	</media>
 	<releases>
+		<release version="2.0" date="2015-02-20" min="2.5.x"><![CDATA[
+			* Added support for Datasources and XSLT to generate urls
+			* Added support for handle overrides
+		]]>
+		</release>
 		<release version="1.3.0" date="2012-06-21" min="2.3.x"><![CDATA[
 			* Added personalized labels supporting xPath at entry level instead of field level.
 		]]>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -25,6 +25,10 @@
 		<item type="image" url="http://symphonyextensions.com/nickdunn/entry_url_field/media/entry_url_field.png">Entry URL Field: Add a hyperlink in the backend to view an entry URL in the frontend</item>
 	</media>
 	<releases>
+		<release version="2.1.1" date="2015-04-01" min="2.5.x"><![CDATA[
+			* Add delegate for XML Importer Post Create
+		]]>
+		</release>
 		<release version="2.1" date="2015-03-18" min="2.5.x"><![CDATA[
 			* Added support for xml importer
 		]]>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -25,6 +25,10 @@
 		<item type="image" url="http://symphonyextensions.com/nickdunn/entry_url_field/media/entry_url_field.png">Entry URL Field: Add a hyperlink in the backend to view an entry URL in the frontend</item>
 	</media>
 	<releases>
+		<release version="2.1" date="2015-03-18" min="2.5.x"><![CDATA[
+			* Added support for xml importer
+		]]>
+		</release>
 		<release version="2.0" date="2015-02-20" min="2.5.x"><![CDATA[
 			* Added support for Datasources and XSLT to generate urls
 			* Added support for handle overrides

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -29,6 +29,7 @@
 		<release version="2.0" date="2018-06-01" min="2.5.x"><![CDATA[
 			* Added support for Datasources and XSLT to generate urls
 			* Added support for handle overrides
+			* Add delegate for XML Importer Post Create
 			* Added support for xml importer
 		]]>
 		<release version="1.3.2" date="2018-01-05" min="2.3.x" max="2.x.x"><![CDATA[

--- a/fields/field.entry_url.php
+++ b/fields/field.entry_url.php
@@ -399,8 +399,13 @@
 			self::$ready = false;
 
 			//Fetch any dependent datasources. These can be used to build the urls in xpath
-			$datasources = explode(',',$this->get('datasources'));
+			if (!empty($this->get('datasources'))){
+				$datasources = explode(',',$this->get('datasources'));
+			} else {
+				$datasources = array();
+			}
 			
+
 			$dom = $this->_driver->getDom($entry,$datasources,$this->get('id'));
 			
 			$value = $this->getExpression($dom, 'expression');

--- a/fields/field.entry_url.php
+++ b/fields/field.entry_url.php
@@ -349,7 +349,6 @@
 	-------------------------------------------------------------------------*/
 		
 		public function appendFormattedElement(XMLElement &$wrapper, $data, $encode = false, $mode = null, $entry_id = null) {
-			if (!self::$ready) return;
 
 			//handle might still be required to generate the full url
 			$element = new XMLElement($this->get('element_name'));

--- a/fields/field.entry_url.php
+++ b/fields/field.entry_url.php
@@ -314,6 +314,31 @@
 		}
 		
 	/*-------------------------------------------------------------------------
+		Import:
+	-------------------------------------------------------------------------*/
+
+		public function getImportModes(){
+			//only support array data
+			return array(
+				'getPostdata' =>	ImportableField::ARRAY_VALUE,
+				'handle' =>	ImportableField::STRING_VALUE
+			);
+		}
+
+		public function prepareImportValue($data, $mode, $entry_id = null){
+
+			if ($mode == $this->getImportModes()['handle']){
+				
+				return array('handle'=>$data);
+				
+			} else {
+				$result = $data;
+			}
+
+			return $result;
+		}
+		
+	/*-------------------------------------------------------------------------
 		Output:
 	-------------------------------------------------------------------------*/
 		

--- a/fields/field.entry_url.php
+++ b/fields/field.entry_url.php
@@ -384,6 +384,10 @@
 	/*-------------------------------------------------------------------------
 		Compile:
 	-------------------------------------------------------------------------*/
+
+		public function setReady($ready){
+			self::$ready = $ready;
+		}
 		
 		public function compile($entry) {
 			self::$ready = false;
@@ -391,9 +395,7 @@
 			//Fetch any dependent datasources. These can be used to build the urls in xpath
 			$datasources = explode(',',$this->get('datasources'));
 			
-			$dom = $this->_driver->getDom($entry,$datasources);
-			
-			self::$ready = true;
+			$dom = $this->_driver->getDom($entry,$datasources,$this->get('id'));
 			
 			$value = $this->getExpression($dom, 'expression');
 			$label = $this->getExpression($dom, 'anchor_label');

--- a/fields/field.entry_url.php
+++ b/fields/field.entry_url.php
@@ -26,11 +26,97 @@
 					`entry_id` INT(11) UNSIGNED NOT NULL,
 					`label` TEXT DEFAULT NULL,
 					`value` TEXT DEFAULT NULL,
+					`handle` VARCHAR(255) DEFAULT NULL,
 					PRIMARY KEY (`id`),
 					KEY `entry_id` (`entry_id`)
 				)
 			");
 		}
+
+    /*-------------------------------------------------------------------------
+        Definition:
+    -------------------------------------------------------------------------*/
+
+	    public function canFilter()
+	    {
+	        if ( $this->get('handle_source') != "" ){
+	        	return true;
+	        } else return false;
+	    }
+
+    /*-------------------------------------------------------------------------
+        Filtering:
+    -------------------------------------------------------------------------*/
+
+	    public function fetchFilterableOperators() {
+	        return array(
+	            array(
+	                'title' => 'handle is',
+	                'filter' => ' ',
+	                'help' => __('Find values that are an exact match for the given string.')
+	            ),
+	            array(
+	                'title' => 'handle contains',
+	                'filter' => 'regexp: ',
+	                'help' => __('Find values that match the given <a href="%s">MySQL regular expressions</a>.', array(
+	                    'http://dev.mysql.com/doc/mysql/en/Regexp.html'
+	                ))
+	            ),
+	            array(
+	                'title' => 'handle does not contain',
+	                'filter' => 'not-regexp: ',
+	                'help' => __('Find values that do not match the given <a href="%s">MySQL regular expressions</a>.', array(
+	                    'http://dev.mysql.com/doc/mysql/en/Regexp.html'
+	                ))
+	            ),
+	        );
+	    }
+
+	    public function buildDSRetrievalSQL($data, &$joins, &$where, $andOperation = false) {
+	        $field_id = $this->get('id');
+
+	        if (self::isFilterRegex($data[0])) {
+	            $this->buildRegexSQL($data[0], array('value', 'handle'), $joins, $where);
+	        } else if ($andOperation) {
+	            foreach ($data as $value) {
+	                $this->_key++;
+	                $value = $this->cleanValue($value);
+	                $joins .= "
+	                    LEFT JOIN
+	                        `tbl_entries_data_{$field_id}` AS t{$field_id}_{$this->_key}
+	                        ON (e.id = t{$field_id}_{$this->_key}.entry_id)
+	                ";
+	                $where .= "
+	                    AND (
+	                        t{$field_id}_{$this->_key}.handle = '{$value}'
+	                    )
+	                ";
+	            }
+	        } else {
+	            if (!is_array($data)) {
+	                $data = array($data);
+	            }
+
+	            foreach ($data as &$value) {
+	                $value = $this->cleanValue($value);
+	            }
+
+	            $this->_key++;
+	            $data = implode("', '", $data);
+	            $joins .= "
+	                LEFT JOIN
+	                    `tbl_entries_data_{$field_id}` AS t{$field_id}_{$this->_key}
+	                    ON (e.id = t{$field_id}_{$this->_key}.entry_id)
+	            ";
+	            $where .= "
+	                AND (
+	                    t{$field_id}_{$this->_key}.handle IN ('{$data}')
+	                )
+	            ";
+	        }
+
+	        return true;
+	    }
 		
 	/*-------------------------------------------------------------------------
 		Settings:
@@ -53,8 +139,41 @@
 				"fields[{$order}][expression]",
 				$this->get('expression')
 			));			
-			$help = new XMLElement('p', __('To access the other fields, use XPath: <code>{entry/field-one} static text {entry/field-two}</code>.'));
+			$help = new XMLElement('p', __('To access the other fields, use XPath: <code>{entry/field-one} static text {entry/field-two}</code>. You can also link to an XSLT file within your workspace folder.'));
 			$help->setAttribute('class', 'help');
+			$label->appendChild($help);
+			$wrapper->appendChild($label);
+			
+			$label = Widget::Label(__('Handle Source (optional field handle)'));
+			$label->appendChild(Widget::Input(
+				"fields[{$order}][handle_source]",
+				$this->get('handle_source')
+			));			
+			$wrapper->appendChild($label);
+
+			$label = Widget::Label(__('Handle Length (max 255)'));
+			$label->appendChild(Widget::Input(
+				"fields[{$order}][handle_length]",
+				$this->get('handle_length')
+			));			
+			$wrapper->appendChild($label);
+
+			$selectedDatasources = explode(',',$this->get('datasources'));
+			$datasources = DatasourceManager::listAll();
+			$options = array();
+			foreach ($datasources as $handle => $datasource) {
+				$selected = in_array($handle,$selectedDatasources);
+				$options[] = array($handle, $selected, $datasource['name']);
+			}
+			$label = Widget::Label(__('Datasources to include for processing'));
+			$label->appendChild(Widget::Select(
+				"fields[{$order}][datasources]",
+				$options,
+				array('multiple'=>'multiple')
+			));			
+			$help = new XMLElement('p', __('Add datasources to allow you to build links which depend on other sections.'));
+			$help->setAttribute('class', 'help');
+			$label->appendChild($help);
 			$wrapper->appendChild($label);
 			
 			$label = Widget::Label();
@@ -85,6 +204,9 @@
 				'field_id'			=> $id,
 				'anchor_label'		=> $this->get('anchor_label'),
 				'expression'		=> $this->get('expression'),
+				'datasources'		=> $this->get('datasources'),
+				'handle_source'		=> $this->get('handle_source'),
+				'handle_length'		=> $this->get('handle_length'),
 				'new_window'		=> $this->get('new_window'),
 				'hide'				=> $this->get('hide')
 			);
@@ -96,11 +218,57 @@
 	/*-------------------------------------------------------------------------
 		Publish:
 	-------------------------------------------------------------------------*/
+
+
+		private function strbefore($string, $substring) {
+			$pos = strpos($string, $substring);
+			if ($pos === false)
+				return $string;
+			else 
+				return(substr($string, 0, $pos));
+		}
+
+		private function strafter($string, $substring) {
+			$pos = strpos($string, $substring);
+			if ($pos === false)
+				return $string;
+			else 
+				return(substr($string, $pos+strlen($substring)));
+		}
 		
 		public function displayPublishPanel(&$wrapper, $data = null, $flagWithError = null, $prefix = null, $postfix = null) {
 			$label = Widget::Label($this->get('label'));
 			$span = new XMLElement('span', null, array('class' => 'frame'));
 			
+			if ( $this->get('handle_source') != "" ){
+
+				$handle = $data['handle'];
+
+				if (!empty($handle)){
+
+					$url = $this->formatURL((string)$data['value']);
+
+					// get part before
+					$urlContents = $this->strbefore($url, $handle);
+
+					// show handle in editable field
+					$urlContents .= "<span contentEditable='true' class='url-entry-handle' data-source='{$this->get('handle_source')}' data-length='{$this->get('handle_length')}'>{$handle}</span>";
+
+					// show whatever is after
+					$urlContents .= $this->strafter($url, $handle);
+
+					$fullEntryUrl = new XMLElement('span', $urlContents, array('class' => 'full-entry-url'));
+					$span->appendChild($fullEntryUrl);
+				} else {
+					$fullEntryUrl = new XMLElement('span', "<span contentEditable='true' class='url-entry-handle empty' data-source='{$this->get('handle_source')}' data-length='{$this->get('handle_length')}'></span>", array('class' => 'full-entry-url'));
+					$span->appendChild($fullEntryUrl);
+				}
+
+				// var_dump($this->get('handle_source'));die;
+				$handleInput = Widget::Input('fields'.$prefix.'['.$this->get('element_name').'][handle]'.$postfix, $handle, 'hidden');
+				$span->appendChild($handleInput);
+			}
+
 			$anchor = Widget::Anchor(
 				(string)$data['label'],
 				is_null($data['value']) ? '#' : $this->formatURL((string)$data['value'])
@@ -135,8 +303,14 @@
 		
 		public function processRawFieldData($data, &$status, $simulate = false, $entry_id = null) {
 			$status = self::__OK__;
+
+			$result =  array('label' => null, 'value' => null);
+
+			if ($data['handle']){
+				$result['handle'] = General::createHandle($data['handle'],$this->get('handle_length'));
+			}
 			
-			return array('label' => null, 'value' => null);
+			return $result;
 		}
 		
 	/*-------------------------------------------------------------------------
@@ -144,11 +318,17 @@
 	-------------------------------------------------------------------------*/
 		
 		public function appendFormattedElement(&$wrapper, $data, $encode = false) {
-			if (!self::$ready) return;
-			
+
+			//handle might still be required to generate the full url
 			$element = new XMLElement($this->get('element_name'));
-			$element->setAttribute('label', General::sanitize($data['label']));
-			$element->setValue(General::sanitize($data['value']));
+			$element->setAttribute('handle', General::sanitize($data['handle']));
+
+			if (self::$ready){
+				//only show the full value if it is ready
+				$element->setAttribute('label', General::sanitize($data['label']));
+				$element->setValue(General::sanitize($data['value']));
+			}
+			
 			$wrapper->appendChild($element);
 		}
 		
@@ -166,6 +346,14 @@
 			// deal with Sym in subdirectories
 			return URL . $url;
 		}
+
+		public function getParameterPoolValue(array $data, $entry_id=NULL) {
+			if ($this->get('handle_source') == '') {
+				return $data['value'];
+			}
+
+			return $data['handle'];
+		}
 		
 	/*-------------------------------------------------------------------------
 		Compile:
@@ -173,13 +361,16 @@
 		
 		public function compile($entry) {
 			self::$ready = false;
+
+			//Fetch any dependent datasources. These can be used to build the urls in xpath
+			$datasources = explode(',',$this->get('datasources'));
 			
-			$xpath = $this->_driver->getXPath($entry);
+			$dom = $this->_driver->getDom($entry,$datasources);
 			
 			self::$ready = true;
 			
-			$value = $this->getExpression($xpath, 'expression');
-			$label = $this->getExpression($xpath, 'anchor_label');
+			$value = $this->getExpression($dom, 'expression');
+			$label = $this->getExpression($dom, 'anchor_label');
 
 			// Save:
 			Symphony::Database()->update(
@@ -193,32 +384,47 @@
 		}
 
 
-		private function getExpression($xpath, $handle){
+		private function getExpression($dom, $handle){
 			$expression = $this->get($handle);
 			$replacements = array();
 
-			// Find queries:
-			preg_match_all('/\{[^\}]+\}/', $expression, $matches);
+			if(substr($expression, -4) === ".xsl"){
+				// If expression is an XSL file should use xsl templates 
+				$xsl = new DOMDocument;
+				// $xsl->load(WORKSPACE.'/sections/pages.xsl');
+				$xsl->load(WORKSPACE.$expression);
 
-			// Find replacements:
-			foreach ($matches[0] as $match) {
-				$results = @$xpath->query(trim($match, '{}'));
+				$proc = new XSLTProcessor;
+				$proc->importStyleSheet($xsl);
 
-				if ($results->length) {
-					$replacements[$match] = $results->item(0)->nodeValue;
-				} else {
-					$replacements[$match] = '';
+				return trim(substr($proc->transformToXML($dom), strlen('<?xml version="1.0"?>')));
+			} else {
+				$xpath = new DOMXPath($dom);
+
+				// Find queries:
+				preg_match_all('/\{[^\}]+\}/', $expression, $matches);
+
+				// Find replacements:
+				foreach ($matches[0] as $match) {
+					$results = @$xpath->query(trim($match, '{}'));
+
+					if ($results->length) {
+						$replacements[$match] = $results->item(0)->nodeValue;
+					} else {
+						$replacements[$match] = '';
+					}
 				}
+
+				// Apply replacements:
+				$value = str_replace(
+					array_keys($replacements),
+					array_values($replacements),
+					$expression
+				);
+
+				return $value;
+
 			}
-
-			// Apply replacements:
-			$value = str_replace(
-				array_keys($replacements),
-				array_values($replacements),
-				$expression
-			);
-
-			return $value;
 		}
 		
 	}

--- a/fields/field.entry_url.php
+++ b/fields/field.entry_url.php
@@ -183,6 +183,12 @@
 			$wrapper->appendChild($label);
 			
 			$label = Widget::Label();
+			$input = Widget::Input("fields[{$order}][sync]", 'yes', 'checkbox');
+			if ($this->get('sync') == 'yes') $input->setAttribute('checked', 'checked');
+			$label->setValue($input->generate() . ' ' . __('Sync handle when it matches source (keeps handle same as source unless manually edited)'));
+			$wrapper->appendChild($label);
+			
+			$label = Widget::Label();
 			$input = Widget::Input("fields[{$order}][hide]", 'yes', 'checkbox');
 			if ($this->get('hide') == 'yes') $input->setAttribute('checked', 'checked');
 			$label->setValue($input->generate() . ' ' . __('Hide this field on publish page'));
@@ -252,7 +258,7 @@
 					$urlContents = $this->strbefore($url, $handle);
 
 					// show handle in editable field
-					$urlContents .= "<span contentEditable='true' class='url-entry-handle' data-source='{$this->get('handle_source')}' data-length='{$this->get('handle_length')}'>{$handle}</span>";
+					$urlContents .= "<span contentEditable='true' class='url-entry-handle' data-source='{$this->get('handle_source')}' data-length='{$this->get('handle_length')}' data-sync='{$this->get('sync')}'>{$handle}</span>";
 
 					// show whatever is after
 					$urlContents .= $this->strafter($url, $handle);

--- a/fields/field.entry_url.php
+++ b/fields/field.entry_url.php
@@ -313,7 +313,7 @@
 			$result =  array('label' => null, 'value' => null);
 
 			if ($data['handle']){
-				$result['handle'] = General::createHandle($data['handle'],$this->get('handle_length'));
+				$result['handle'] = Lang::createHandle($data['handle'],$this->get('handle_length'));
 			}
 			
 			return $result;

--- a/fields/field.entry_url.php
+++ b/fields/field.entry_url.php
@@ -383,6 +383,10 @@
 	/*-------------------------------------------------------------------------
 		Compile:
 	-------------------------------------------------------------------------*/
+
+		public function setReady($ready){
+			self::$ready = $ready;
+		}
 		
 		public function compile($entry) {
 			self::$ready = false;
@@ -390,9 +394,7 @@
 			//Fetch any dependent datasources. These can be used to build the urls in xpath
 			$datasources = explode(',',$this->get('datasources'));
 			
-			$dom = $this->_driver->getDom($entry,$datasources);
-			
-			self::$ready = true;
+			$dom = $this->_driver->getDom($entry,$datasources,$this->get('id'));
 			
 			$value = $this->getExpression($dom, 'expression');
 			$label = $this->getExpression($dom, 'anchor_label');


### PR DESCRIPTION
1. Added support for external datasources.
   
   This allows developers to link other datasources with the main entry, for example when the url would depend on a third-party section, such as a category with potentially a parent category. `domain/category/subcategory/handle`
2. Added support for XSLT Utilities
   
   As datasources add complexity, XPATH is not necessarily sufficient to generate complicated url handles, thus linking to an XSL template makes the url generation simpler, you can even use whatever you had previously to generate links on front-end using recursion for example.
3. Handle Override

There's also the option to override a dynamic portion of the url named handle. By setting the `handle_source` setting when creating the entry, the field will pre-populate using javascript whatever is in the source field. Once the field is edited it will not update automatically but requires the use of the reload icon to sync. If `handle_source` is omitted the field will behave just as it did before.

![Handle Override UI](https://cloud.githubusercontent.com/assets/859775/6264483/a7ff1512-b824-11e4-8d65-b5d151567682.png)

UI example when the entry url field is placed just underneath the original source field, the field label is hidden to make it seem part of the original title field for the user.
1. Filtering

As this supports handle overrides, one might obviously want to filter by Handles, this has been added in when a field has the `handle_source` available. Filtering and suggestions also work within the backend interface.

PS. I've bumped version to 1.5 but maybe 2.0 might be more appropriate if the changes are accepted.
