### PR TITLE
Fix update function's previous version argument name

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -8,7 +8,7 @@
 			Symphony::Database()->query("DROP TABLE `tbl_fields_entry_url`");
 		}
 
-		public function update($previousVersion = false){
+		public function update($prev_version = false){
 			if( version_compare($prev_version, '1.3.0', '<') ){
 				$fields = Symphony::Database()->fetch("SELECT `field_id`,`anchor_label` FROM `tbl_fields_entry_url`");
 


### PR DESCRIPTION
In 69ff4ff191b5313bef40e8b40fccf316637c3abf, the argument name was (presumably inadvertently) changed in the function signature but not in the body. This led to the 'label' column add failing when the column already exists.